### PR TITLE
exemple de code pour fleches

### DIFF
--- a/fleches.js
+++ b/fleches.js
@@ -1,0 +1,23 @@
+// Code pour intercepter les fleches gauche-droite
+
+// Utiliser l'événement "keydown", car "keypress" ne tient pas compte des flèches
+// selon https://stackoverflow.com/questions/19347269/
+
+$('body').on('keydown',function ( event ) {
+
+    var toucheClavier = event.which;
+
+    if ( toucheClavier == 39 ) {
+
+        console.log("flèche droite");
+
+    } else if ( toucheClavier == 37 ) {
+
+        console.log("flèche gauche");
+    }
+
+    else {
+        console.log("raté");
+    }
+
+});

--- a/versionsolo.html
+++ b/versionsolo.html
@@ -21,6 +21,7 @@
 		<script src="jquery.js"></script>
 
 		<script src="index.js"></script>
+        <script src="fleches.js"></script>
 
 
     </body>


### PR DESCRIPTION
Voici un exemple de code Javascript qui fonctionne!

Ça marche en utilisant l'événement Javascript "keydown" au lieu de "keypress".

La raison est que "keypress" ne tient pas compte des flèches, mais uniquement des caractères visibles.